### PR TITLE
Fix flush crash when deleting an inherited ManyToMany target (#105)

### DIFF
--- a/src/Service/AssociationImpactAnalyzer.php
+++ b/src/Service/AssociationImpactAnalyzer.php
@@ -218,6 +218,16 @@ final readonly class AssociationImpactAnalyzer
      */
     private function canReadCollectionThroughCriteria(PersistentCollection $items): bool
     {
+        // Doctrine's matching()/Criteria is unsupported for ManyToMany associations
+        // whose target entity uses class inheritance: ManyToManyPersister::loadCriteria
+        // builds a ResultSetMapping via addRootEntityFromClassMetadata, which throws
+        // "ResultSetMappingBuilder does not currently support your inheritance scheme.".
+        // Bail out so the caller falls back to standard iteration / lazy loading, which
+        // hydrates inherited entities correctly.
+        if ($items->getMapping()->isManyToMany() && !$items->getTypeClass()->isInheritanceTypeNone()) {
+            return false;
+        }
+
         return !$items->isInitialized() && !$items->isDirty();
     }
 

--- a/tests/Functional/Entity/InheritedManyToManyEntities.php
+++ b/tests/Functional/Entity/InheritedManyToManyEntities.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rcsofttech\AuditTrailBundle\Tests\Functional\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Rcsofttech\AuditTrailBundle\Attribute\Auditable;
+
+/**
+ * Owner side of a ManyToMany whose target entity ({@see Membership}) uses class
+ * inheritance. Reproduces the crash where reading this collection through
+ * Doctrine's Criteria fast-path fails with
+ * "ResultSetMappingBuilder does not currently support your inheritance scheme.".
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'club')]
+#[Auditable]
+class Club
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    // @phpstan-ignore property.unusedType
+    private ?int $id = null;
+
+    #[ORM\Column]
+    private string $name;
+
+    /**
+     * @var Collection<int, Membership>
+     */
+    #[ORM\ManyToMany(targetEntity: Membership::class, inversedBy: 'clubs', cascade: ['persist'])]
+    #[ORM\JoinTable(name: 'club_membership')]
+    private Collection $memberships;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+        $this->memberships = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return Collection<int, Membership>
+     */
+    public function getMemberships(): Collection
+    {
+        return $this->memberships;
+    }
+
+    public function addMembership(Membership $membership): void
+    {
+        if (!$this->memberships->contains($membership)) {
+            $this->memberships->add($membership);
+            $membership->addClub($this);
+        }
+    }
+
+    public function removeMembership(Membership $membership): void
+    {
+        if ($this->memberships->removeElement($membership)) {
+            $membership->removeClub($this);
+        }
+    }
+}
+
+/**
+ * Inherited (JOINED) target of the {@see Club} ManyToMany association.
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'membership')]
+#[ORM\InheritanceType('JOINED')]
+#[ORM\DiscriminatorColumn(name: 'discr', type: 'string')]
+#[ORM\DiscriminatorMap(['membership' => Membership::class, 'premium' => PremiumMembership::class])]
+#[Auditable]
+abstract class Membership
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    // @phpstan-ignore property.unusedType
+    private ?int $id = null;
+
+    #[ORM\Column]
+    private string $label;
+
+    /**
+     * @var Collection<int, Club>
+     */
+    #[ORM\ManyToMany(targetEntity: Club::class, mappedBy: 'memberships')]
+    private Collection $clubs;
+
+    public function __construct(string $label)
+    {
+        $this->label = $label;
+        $this->clubs = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    public function setLabel(string $label): void
+    {
+        $this->label = $label;
+    }
+
+    /**
+     * @return Collection<int, Club>
+     */
+    public function getClubs(): Collection
+    {
+        return $this->clubs;
+    }
+
+    public function addClub(Club $club): void
+    {
+        if (!$this->clubs->contains($club)) {
+            $this->clubs->add($club);
+        }
+    }
+
+    public function removeClub(Club $club): void
+    {
+        $this->clubs->removeElement($club);
+    }
+}
+
+#[ORM\Entity]
+class PremiumMembership extends Membership
+{
+    #[ORM\Column(nullable: true)]
+    private ?string $tier = null;
+
+    public function getTier(): ?string
+    {
+        return $this->tier;
+    }
+
+    public function setTier(string $tier): void
+    {
+        $this->tier = $tier;
+    }
+}

--- a/tests/Functional/ManyToManyInheritanceDeleteTest.php
+++ b/tests/Functional/ManyToManyInheritanceDeleteTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rcsofttech\AuditTrailBundle\Tests\Functional;
+
+use Doctrine\ORM\PersistentCollection;
+use Rcsofttech\AuditTrailBundle\Entity\AuditLog;
+use Rcsofttech\AuditTrailBundle\Enum\AuditAction;
+use Rcsofttech\AuditTrailBundle\Tests\Functional\Entity\Club;
+use Rcsofttech\AuditTrailBundle\Tests\Functional\Entity\Membership;
+use Rcsofttech\AuditTrailBundle\Tests\Functional\Entity\PremiumMembership;
+
+use function array_map;
+use function array_slice;
+
+/**
+ * Regression test for issue #105: deleting an entity that is the target of a
+ * ManyToMany association whose target class uses inheritance crashed during
+ * flush with "ResultSetMappingBuilder does not currently support your
+ * inheritance scheme." because the delete impact analyzer read the owner
+ * collection through Doctrine's Criteria fast-path, which ManyToManyPersister
+ * does not support for inherited targets.
+ */
+final class ManyToManyInheritanceDeleteTest extends AbstractFunctionalTestCase
+{
+    public function testDeletingInheritedManyToManyTargetDoesNotCrashAndAuditsOwner(): void
+    {
+        self::bootKernel();
+        $em = $this->getEntityManager();
+
+        $club = new Club('chess club');
+        $memberships = [];
+        foreach (['alice', 'bob', 'carol', 'dave', 'erin'] as $label) {
+            $membership = new PremiumMembership($label);
+            $club->addMembership($membership);
+            $memberships[] = $membership;
+        }
+
+        $em->persist($club);
+        $em->flush();
+
+        $clubId = $club->getId();
+        self::assertNotNull($clubId);
+
+        $membershipIds = [];
+        foreach ($memberships as $membership) {
+            $membershipId = $membership->getId();
+            self::assertNotNull($membershipId);
+            $membershipIds[] = $membershipId;
+        }
+
+        $deletedMembershipId = $membershipIds[0];
+        $expectedOldIds = array_map('strval', $membershipIds);
+        $expectedNewIds = array_map('strval', array_slice($membershipIds, 1));
+
+        $em->clear();
+
+        $club = $em->find(Club::class, $clubId);
+        $deletedMembership = $em->find(Membership::class, $deletedMembershipId);
+        self::assertInstanceOf(Club::class, $club);
+        self::assertInstanceOf(PremiumMembership::class, $deletedMembership);
+
+        $clubMemberships = $club->getMemberships();
+        self::assertInstanceOf(PersistentCollection::class, $clubMemberships);
+        self::assertFalse($clubMemberships->isInitialized());
+
+        // Before the fix this flush threw:
+        // "ResultSetMappingBuilder does not currently support your inheritance scheme."
+        $em->remove($deletedMembership);
+        $em->flush();
+
+        $clubAudit = $em->getRepository(AuditLog::class)->findOneBy([
+            'entityClass' => Club::class,
+            'entityId' => (string) $clubId,
+            'action' => AuditAction::Update,
+        ], ['createdAt' => 'DESC']);
+
+        self::assertNotNull($clubAudit, 'Deleting a membership must create an update audit log for the related club.');
+        $actualOldIds = $clubAudit->oldValues['memberships'] ?? null;
+        $actualNewIds = $clubAudit->newValues['memberships'] ?? null;
+        self::assertIsArray($actualOldIds);
+        self::assertIsArray($actualNewIds);
+        self::assertEqualsCanonicalizing($expectedOldIds, $actualOldIds);
+        self::assertEqualsCanonicalizing($expectedNewIds, $actualNewIds);
+
+        // The membership row is actually gone: four of the original five remain.
+        self::assertSame(4, $em->getRepository(Membership::class)->count([]));
+    }
+}


### PR DESCRIPTION
Fixes #105.

### Problem

Deleting an entity that is the target of a **ManyToMany** association whose **target class uses class inheritance** (`JOINED` / `SINGLE_TABLE`) crashes during `EntityManager::flush()`:

```
ResultSetMappingBuilder does not currently support your inheritance scheme.
(InvalidArgumentException)
```

`AssociationImpactAnalyzer::canReadCollectionThroughCriteria()` returns `true` for any clean, uninitialized `PersistentCollection`, so `resolveCollectionItems()` / `resolveCollectionIds()` read the owner collection via `matching(Criteria::create())`. Doctrine's `ManyToManyPersister::loadCriteria()` builds a `ResultSetMapping` through `ResultSetMappingBuilder::addRootEntityFromClassMetadata()`, which explicitly rejects inheritance schemes — a long-standing Doctrine limitation, so the bundle can't rely on `matching()` for those associations.

### Fix

Skip the Criteria fast-path when the association is ManyToMany **and** the target entity uses inheritance, falling back to the existing iteration / lazy-loading path (which hydrates inherited entities correctly):

```php
private function canReadCollectionThroughCriteria(PersistentCollection $items): bool
{
    if ($items->getMapping()->isManyToMany() && !$items->getTypeClass()->isInheritanceTypeNone()) {
        return false;
    }

    return !$items->isInitialized() && !$items->isDirty();
}
```

This is a behavior fix only — no public API change.

### Test

Adds a functional regression test (`ManyToManyInheritanceDeleteTest`) with a new fixture (`Club` → ManyToMany → inherited `Membership` / `PremiumMembership`, `JOINED`). It mirrors the existing `CollectionInitializationSafetyTest` delete-impact scenario but with an inherited target: it deletes a membership while the owner collection is clean and uninitialized, and asserts the flush no longer crashes and the owner audit log records the `5 → 4` change. The test fails on `main` with the exact `ResultSetMappingBuilder` error and passes with the fix.

`composer check` is green (921 tests, PHPStan, php-cs-fixer).